### PR TITLE
Added thread_create.py

### DIFF
--- a/cogs/thread_create.py
+++ b/cogs/thread_create.py
@@ -1,0 +1,23 @@
+import discord
+from discord.ext import commands
+import asyncio
+
+class ThreadCreate(commands.Cog):
+
+    def __init__(self, client):
+        self.client = client
+
+    @commands.Cog.listener()
+    async def on_thread_create(self, thread):
+        if thread.parent.id == 1188491894741811241: # Füge hier die ID des Forum-Kanals ein (Rechtsklick auf den Kanal, danach ganz unten ID kopieren)
+            embed = discord.Embed(
+            description="Vielen Dank, dass du dich gemeldet hast. Wir schätzen dies sehr.",
+            color=discord.Color.random(),
+            )
+            await asyncio.sleep(3) # Verzögerung von 3 Sekunden beim Senden
+            await thread.send(embed=embed)
+
+
+async def setup(client):
+    await client.add_cog(ThreadCreate(client))
+


### PR DESCRIPTION
# Tutorial für die automatischen Antworten bei Foren-Kanälen.

- Funktion siehe z.B. bei Bl4cklist Kanal: Die Seelsorge
- Preview der Funktion siehe Bild

![89PAORJa](https://github.com/Bl4cklist-Discord/discord-bot-python/assets/91845380/6f193847-f22c-4490-b9c6-93d083b6e378)